### PR TITLE
Changed layout structure to support full screen headers

### DIFF
--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -65,56 +65,60 @@
     <?=$this->headScript()?>
   </head>
   <body>
-    <div class="container">
-      <? // Set up the search box -- there are three possible cases:
-        // 1. No search box was set; we should default to the normal box
-        // 2. It was set to false; we should display nothing
-        // 3. It is set to a custom string; we should display the provided version
-        // Set up default search box if no data was provided from the template;
-        // this covers case 1.  Cases 2 and 3 are then covered by logic below.
-        if (!isset($this->layout()->searchbox)) {
-          $this->layout()->searchbox = $this->render('search/searchbox.phtml');
-        }
-      ?>
-      <header role="banner" class="navbar hidden-print">
+    <? // Set up the search box -- there are three possible cases:
+      // 1. No search box was set; we should default to the normal box
+      // 2. It was set to false; we should display nothing
+      // 3. It is set to a custom string; we should display the provided version
+      // Set up default search box if no data was provided from the template;
+      // this covers case 1.  Cases 2 and 3 are then covered by logic below.
+      if (!isset($this->layout()->searchbox)) {
+        $this->layout()->searchbox = $this->render('search/searchbox.phtml');
+      }
+    ?>
+    <header role="banner" class="navbar hidden-print">
+      <div class="container">
         <a class="sr-only" href="#content">Skip to content</a>
         <?=$this->render('header.phtml')?>
-      </header>
+      </div>
+    </header>
+    <div class="container">
       <nav class="nav searchbox hidden-lg hidden-print">
         <?=$this->layout()->searchbox ?>
       </nav>
       <? if((!isset($this->layout()->showBreadcrumbs) || $this->layout()->showBreadcrumbs == true)
-        && !empty($this->layout()->breadcrumbs)
-        && $this->layout()->breadcrumbs !== false
+          && !empty($this->layout()->breadcrumbs)
+          && $this->layout()->breadcrumbs !== false
       ): ?>
         <ul class="breadcrumb hidden-print">
-        <? if(is_array($this->layout()->breadcrumbs)): ?>
-          <? if(count($this->layout()->breadcrumbs) > 1): ?>
-            <?=$this->render('breadcrumbs/multi.phtml', array(
-                'parents' => $this->layout()->breadcrumbs,
-                'title'   => $this->layout()->title,
-                'end'     => $this->layout()->breadcrumbEnd,
-                'from'    => $this->layout()->from
-              )) ?>
+          <? if(is_array($this->layout()->breadcrumbs)): ?>
+            <? if(count($this->layout()->breadcrumbs) > 1): ?>
+              <?=$this->render('breadcrumbs/multi.phtml', array(
+                      'parents' => $this->layout()->breadcrumbs,
+                      'title'   => $this->layout()->title,
+                      'end'     => $this->layout()->breadcrumbEnd,
+                      'from'    => $this->layout()->from
+                  )) ?>
+            <? else: ?>
+              <?=$this->render('breadcrumbs/default.phtml', array(
+                      'parents' => $this->layout()->breadcrumbs,
+                      'title'   => $this->layout()->title
+                  )) ?>
+            <? endif; ?>
           <? else: ?>
-            <?=$this->render('breadcrumbs/default.phtml', array(
-                'parents' => $this->layout()->breadcrumbs,
-                'title'   => $this->layout()->title
-              )) ?>
+            <?=$this->layout()->breadcrumbs ?>
           <? endif; ?>
-        <? else: ?>
-          <?=$this->layout()->breadcrumbs ?>
-        <? endif; ?>
         </ul>
       <? endif; ?>
       <div role="main" class="main row">
         <?=$this->layout()->content?>
       </div>
-      <footer role="contentinfo" class="hidden-print">
+    </div>
+    <footer role="contentinfo" class="hidden-print">
+      <div class="container">
         <?=$this->render('footer.phtml')?>
         <?=$this->layout()->poweredBy ?>
-      </footer>
-    </div>
+      </div>
+    </footer>
     <!-- MODAL IN CASE WE NEED ONE -->
     <div id="modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modalTitle" aria-hidden="true">
       <div class="modal-dialog">


### PR DESCRIPTION
Hello Chris

We have a suggestion to change the layout structure. Basically we would like to have the footer and the header outside the bootstrap "container" element. Like this it would be possible for the header and footer elements to stretch over the full screen.
There are a lot of bootstrap templates doing exactly that (e.g. http://getbootstrap.com/examples/theme/).

We have not found any issues with the current javascript or css implementation nor should there be any visible effects on the current layout.

What do you think?

Kind regards
Markus
