### PR TITLE
* turns list headers in footer into proper headings

### DIFF
--- a/themes/bootstrap3/templates/footer.phtml
+++ b/themes/bootstrap3/templates/footer.phtml
@@ -1,14 +1,14 @@
 <footer class="hidden-print">
   <div class="footer-container">
     <div class="footer-column">
-      <p><strong><?=$this->transEsc('Search Options')?></strong></p>
+      <h2><?=$this->transEsc('Search Options')?></h2>
       <ul>
         <li><a href="<?=$this->url('search-history')?>"><?=$this->transEsc('Search History')?></a></li>
         <li><a href="<?=$this->url('search-advanced')?>"><?=$this->transEsc('Advanced Search')?></a></li>
       </ul>
     </div>
     <div class="footer-column">
-      <p><strong><?=$this->transEsc('Find More')?></strong></p>
+      <h2><?=$this->transEsc('Find More')?></h2>
       <ul>
         <li><a href="<?=$this->url('browse-home')?>"><?=$this->transEsc('Browse the Catalog')?></a></li>
         <li><a href="<?=$this->url('alphabrowse-home')?>"><?=$this->transEsc('Browse Alphabetically')?></a></li>
@@ -18,7 +18,7 @@
       </ul>
     </div>
     <div class="footer-column">
-      <p><strong><?=$this->transEsc('Need Help?')?></strong></p>
+      <h2><?=$this->transEsc('Need Help?')?></h2>
       <ul>
         <li><a href="<?=$this->url('help-home')?>?topic=search&amp;_=<?=time() ?>" data-lightbox class="help-link"><?=$this->transEsc('Search Tips')?></a></li>
         <li><a href="<?=$this->url('content-page', ['page' => 'asklibrary']) ?>"><?=$this->transEsc('Ask a Librarian')?></a></li>


### PR DESCRIPTION
Hi Chris,
hope I'm creating this in the right repo. If not, please advise!
This is the first PR of catches from our accessibility report that also apply to the Bootstrap3 theme and haven't been fixed yet.
- In **footer.phtml** -- there are headings above the lists that are not marked as such starting in line 5 -- they are marked `<p><strong><?=$this->transEsc('Search Options')?></strong></p>` for example, but should really be `<h2>` (my guess)