### PR TITLE
* turns h2 heading in advanced search into h1 and h4 sidebar heading …

### DIFF
--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -99,7 +99,7 @@
             <?php endif; ?>
             <div id="group<?=$group ?>" class="adv-group">
               <div class="adv-group-terms">
-                <label class="adv-group-label"><?=$this->transEsc("adv_search_label")?>:</label>
+                <h2 class="adv-group-label"><?=$this->transEsc("adv_search_label")?>:</h2>
                 <?php for($search = 0; $search < 3 || (isset($setQueries[$group]) && $search < count($setQueries[$group])); $search++): ?>
                   <?php if($group == 0 && $search == 0): ?>
                     <div id="new_search_template">

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -158,7 +158,7 @@
         <input type="hidden" name="dfApplied" value="1" />
       <?php endif ?>
       <?php if (!empty($searchFilters)): ?>
-        <h4><?=$this->transEsc("adv_search_filters")?></h4>
+        <h2><?=$this->transEsc("adv_search_filters")?></h2>
         <div class="facet-group">
           <label class="checkbox">
             <input type="checkbox" checked="checked" class="checkbox-select-all"/>

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -75,7 +75,7 @@
         <input type="hidden" name="sort" value="<?=$this->escapeHtmlAttr($lastSort)?>" />
       <?php endif; ?>
       <div class="clearfix">
-        <h2 class="pull-left flip"><?=$this->transEsc('Advanced Search')?></h2>
+        <h1 class="pull-left flip"><?=$this->transEsc('Advanced Search')?></h1>
         <div id="groupJoin" class="form-inline pull-right flip">
           <label for="groupJoinOptions"><?=$this->transEsc("search_match")?>:</label>
           <select id="groupJoinOptions" name="join" class="form-control">
@@ -174,7 +174,7 @@
           </div>
         <?php endforeach; ?>
       <?php endif; ?>
-      <h4><?=$this->transEsc("Search Tips")?></h4>
+      <h2><?=$this->transEsc("Search Tips")?></h2>
       <div class="facet-group">
         <a class="facet help-link" data-lightbox href="<?=$this->url('help-home')?>?topic=advsearch&amp;_=<?=time() ?>"><?=$this->transEsc("Help with Advanced Search")?></a>
         <a class="facet help-link" data-lightbox href="<?=$this->url('help-home')?>?topic=search&amp;_=<?=time() ?>"><?=$this->transEsc("Help with Search Operators")?></a>


### PR DESCRIPTION
…into h2 for accessibility

Another PR from catches from our accessibility report:
- **advanced search** has issues with the headings hierarchy: search/advanced/layout.phtml requires a `<h1>` on top of the search bar ([line 78](https://github.com/vufind-org/vufind/blob/bdc37b07ceae2214de360420083d30017ffc54d0/themes/bootstrap3/templates/search/advanced/layout.phtml#L78)) and the "Search Tips" heading in the sidebar mustn't be a h4 but should be a h2 rather (my guess)
- explanation: as a h4 it would require a superordinate h3 (which would require a superordinate h2)
- I'm avoiding to mess with Sandal but I guess in sandal.scss you should change the lines
```
.sidebar .checkbox-filter,
.sidebar > h4,
```
into something like
```
.sidebar .checkbox-filter,
.sidebar > h4,
.sidebar .checkbox-filter,
.sidebar > h2 {
  margin-left: 1rem;
  margin-right: 1rem;
}
```
or even include h3 also -- you'll know the best way forward